### PR TITLE
Feature - check config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Voici son format attendu :
 - fireSpreadProbability représente la probabilité, comprise entre 0 et 1 inclus, que le feu se propage aux arbres voisins
 - ignitedTrees est un tableau de coordonnées [x, y] d'arbres en feu à la première étape de la simulation
 - treeHeight & treeWidth définissent les dimensions en pixel de chaque arbre dans l'interface graphique de la simulation
+
+La simulation affichera un message d'erreur avant de fermer le programme si des valeurs en configuration sont inutilisables.\
+Le détail des erreurs est affiché dans le flux d'erreur.\
+Si les coordonnées d'un arbre initialement en feu sont en dehors des dimensions de la forêt, l'arbre est ignoré et l'erreur est consignée dans le flux d'erreur.

--- a/src/main/java/fr/LaurentFE/forestFire/ForestFire.java
+++ b/src/main/java/fr/LaurentFE/forestFire/ForestFire.java
@@ -5,6 +5,5 @@ import fr.LaurentFE.forestFire.controller.DisplayWindow;
 public class ForestFire {
     public static void main(String[] args) {
         DisplayWindow displayWindow = new DisplayWindow();
-        displayWindow.setVisible(true);
     }
 }

--- a/src/main/java/fr/LaurentFE/forestFire/controller/DisplayWindow.java
+++ b/src/main/java/fr/LaurentFE/forestFire/controller/DisplayWindow.java
@@ -24,26 +24,32 @@ public class DisplayWindow extends JFrame implements KeyListener {
         });
 
         Config config = Config.readConfig("./config.json");
-        forest = new Forest(
-                config.getForestHeight(),
-                config.getForestWidth(),
-                config.getFireSpreadProbability());
-        forest.initialIgnite(config.getIgnitedTrees());
+        if (!config.isConfigUsable()) {
+            forest = null;
+            drawingPanel = null;
+            unusableConfigClose();
+        } else {
+            forest = new Forest(
+                    config.getForestHeight(),
+                    config.getForestWidth(),
+                    config.getFireSpreadProbability());
+            forest.initialIgnite(config.getIgnitedTrees());
 
-        drawingPanel = new DrawingPanel(
-                config.getTreeWidth(),
-                config.getTreeHeight(),
-                forest);
+            drawingPanel = new DrawingPanel(
+                    config.getTreeWidth(),
+                    config.getTreeHeight(),
+                    forest);
 
-        this.add(drawingPanel, BorderLayout.CENTER);
-        this.add(new Label(
-                "Press any key to go to the next step of the simulation", Label.CENTER),
-                BorderLayout.SOUTH);
-        this.pack();
+            this.add(drawingPanel, BorderLayout.CENTER);
+            this.add(new Label(
+                            "Press any key to go to the next step of the simulation", Label.CENTER),
+                    BorderLayout.SOUTH);
+            this.pack();
 
-        this.addKeyListener(this);
-        this.setLocationRelativeTo(null);
-
+            this.addKeyListener(this);
+            this.setLocationRelativeTo(null);
+            this.setVisible(true);
+        }
     }
 
     // Displays an option panel to check if user really wants to exit program
@@ -56,6 +62,18 @@ public class DisplayWindow extends JFrame implements KeyListener {
         if (exitValue == JOptionPane.YES_OPTION) {
             dispose();
         }
+    }
+
+    // Displays an option panel to inform the user that the config doesn't allow the simulation to run
+    private void unusableConfigClose() {
+        JOptionPane.showMessageDialog(
+                null,
+                "The config.json file contains values that do not allow the simulation to run.\n" +
+                        "Check the error stream.",
+                "config.json value error",
+                JOptionPane.ERROR_MESSAGE);
+
+        dispose();
     }
 
     @Override

--- a/src/main/java/fr/LaurentFE/forestFire/model/Config.java
+++ b/src/main/java/fr/LaurentFE/forestFire/model/Config.java
@@ -94,4 +94,29 @@ public class Config {
             throw new RuntimeException(e);
         }
     }
+
+    public boolean isConfigUsable() {
+        boolean r = true;
+        if (forestHeight <= 0) {
+            System.err.println("config.json:forestHeight must be greater than 0");
+            r = false;
+        }
+        if (forestWidth <= 0) {
+            System.err.println("config.json:forestWidth must be greater than 0");
+            r = false;
+        }
+        if (fireSpreadProbability < 0 || fireSpreadProbability > 1) {
+            System.err.println("config.json:fireSpearProbability must be between 0 and 1 (included)");
+            r = false;
+        }
+        if (treeHeight <= 0) {
+            System.err.println("config.json:treeHeight must be greater than 0");
+            r = false;
+        }
+        if (treeWidth <= 0) {
+            System.err.println("config.json:treeWidth must be greater than 0");
+            r = false;
+        }
+        return r;
+    }
 }

--- a/src/main/java/fr/LaurentFE/forestFire/model/Forest.java
+++ b/src/main/java/fr/LaurentFE/forestFire/model/Forest.java
@@ -21,9 +21,14 @@ public class Forest {
     // Ignites the trees set in the config.json
     public void initialIgnite(int[][] treeCoords) {
         for(int[] treePos : treeCoords) {
-            Tree t = trees[treePos[1]][treePos[0]];
-            t.ignite();
-            ignitedTrees.add(t);
+            if (isWithinBounds(treePos[0], treePos[1])) {
+                Tree t = trees[treePos[1]][treePos[0]];
+                t.ignite();
+                ignitedTrees.add(t);
+            } else {
+                System.err.println("config.json:ignitedTrees["+treePos[0]+","+treePos[1]+"] is out of bounds, and " +
+                        "has been ignored");
+            }
         }
     }
 


### PR DESCRIPTION
At the start of the simulation, the config values are checked to see if the simulation can run based on them.

If not, an error JOptionPane is displayed, and config errors are logged in the System.err stream. 

Out of bounds ignitedTrees are simply ignored in the simulation, and logged in the System.err stream.